### PR TITLE
Decoded POST values before saving into  collection

### DIFF
--- a/PSWebGui.psd1
+++ b/PSWebGui.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSWebGui.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.15.3'
+ModuleVersion = '0.15.4'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/PSWebGui.psm1
+++ b/PSWebGui.psm1
@@ -413,13 +413,19 @@ Function Show-PSWebGUI
                 $global:_POST = @{}
                 $body.split('&') | ForEach-Object {
                     $part = $_.split('=')
+
+                    # POST variable name
+                    $post_name=$part[0]
+
+                    # Decode POST variable value
+                    $post_value=[System.Web.HttpUtility]::UrlDecode($part[1])
                     
                     # If post variable name is already in $_POST collection, add new value to array
-                    if ($global:_POST.ContainsKey($part[0])){
-                        $global:_POST[$part[0]]+=$part[1]
+                    if ($global:_POST.ContainsKey($post_name)){
+                        [array]$global:_POST[$post_name]+=$post_value
                     }
                     else{
-                        $global:_POST.add($part[0], @($part[1]))
+                        $global:_POST.add($post_name, $post_value)
                     }
                 }
 


### PR DESCRIPTION
 POST variables that are not already in  collection are saved as string, not as an array